### PR TITLE
make GSO-Update also copy Wikidata and FactGrid identifiers

### DIFF
--- a/src/Entity/Gso/Persons.php
+++ b/src/Entity/Gso/Persons.php
@@ -79,6 +79,12 @@ class Persons
 
     #[ORM\Column(type: 'string', length: 200, nullable: true)]
     private $viaf;
+    
+    #[ORM\Column(type: 'string', length: 200, nullable: true)]
+    private $wikidata;
+
+    #[ORM\Column(type: 'string', length: 200, nullable: true)]
+    private $factgrid;
 
     public function getId(): ?int
     {
@@ -343,6 +349,30 @@ class Persons
     public function setViaf(?string $viaf): self
     {
         $this->viaf = $viaf;
+
+        return $this;
+    }
+
+    public function getWikidata(): ?string
+    {
+        return $this->wikidata;
+    }
+
+    public function setWikidata(?string $wikidata): self
+    {
+        $this->wikidata = $wikidata;
+
+        return $this;
+    }
+
+    public function getFactgrid(): ?string
+    {
+        return $this->factgrid;
+    }
+
+    public function setFactgrid(?string $factgrid): self
+    {
+        $this->factgrid = $factgrid;
 
         return $this;
     }


### PR DESCRIPTION
The gso-update function has so far not only not copied, but actually removed the Wikidata and FactGrid identifiers for entries that don't have such entries in WIAG yet (are only in the Digitales Personenregister). This change simply makes the update copy these identifiers from GSO.